### PR TITLE
yaml spacing off by two

### DIFF
--- a/docs/openshift/post-install/index.md
+++ b/docs/openshift/post-install/index.md
@@ -43,7 +43,7 @@ Based on requirements, choose one of the following options:
             accessModes:
             - ReadWriteOnce
             resources:
-            requests:
+              requests:
                 storage: 100Gi
             storageClassName: nutanix-volume
 
@@ -110,7 +110,7 @@ Based on requirements, choose one of the following options:
             accessModes:
             - ReadWriteMany
             resources:
-            requests:
+              requests:
                 storage: 100Gi
             storageClassName: nutanix-files-dynamic
 


### PR DESCRIPTION
A straight copy and paste will not work when creating a pvc for the image-registry because requests: needs to be indented two spaces.