### PR TITLE
Fix CAPX Addon docs CNI/CSI typo

### DIFF
--- a/docs/capx/v0.5.x/addons/install_csi_driver.md
+++ b/docs/capx/v0.5.x/addons/install_csi_driver.md
@@ -102,7 +102,7 @@ Then replace `ClusterResourceSet=false` with `ClusterResourceSet=true`.
 
 ### Prepare the Nutanix CSI `ClusterResourceSet`
 
-#### Create the `ConfigMap` for the CNI Plugin
+#### Create the `ConfigMap` for the CSI Plugin
 
 First, create a `ConfigMap` that contains a YAML manifest with all resources to install the Nutanix CSI driver.
 

--- a/docs/capx/v1.0.x/addons/install_csi_driver.md
+++ b/docs/capx/v1.0.x/addons/install_csi_driver.md
@@ -102,7 +102,7 @@ Then replace `ClusterResourceSet=false` with `ClusterResourceSet=true`.
 
 ### Prepare the Nutanix CSI `ClusterResourceSet`
 
-#### Create the `ConfigMap` for the CNI Plugin
+#### Create the `ConfigMap` for the CSI Plugin
 
 First, create a `ConfigMap` that contains a YAML manifest with all resources to install the Nutanix CSI driver.
 

--- a/docs/capx/v1.1.x/addons/install_csi_driver.md
+++ b/docs/capx/v1.1.x/addons/install_csi_driver.md
@@ -102,7 +102,7 @@ Then replace `ClusterResourceSet=false` with `ClusterResourceSet=true`.
 
 ### Prepare the Nutanix CSI `ClusterResourceSet`
 
-#### Create the `ConfigMap` for the CNI Plugin
+#### Create the `ConfigMap` for the CSI Plugin
 
 First, create a `ConfigMap` that contains a YAML manifest with all resources to install the Nutanix CSI driver.
 

--- a/docs/capx/v1.2.x/addons/install_csi_driver.md
+++ b/docs/capx/v1.2.x/addons/install_csi_driver.md
@@ -102,7 +102,7 @@ Then replace `ClusterResourceSet=false` with `ClusterResourceSet=true`.
 
 ### Prepare the Nutanix CSI `ClusterResourceSet`
 
-#### Create the `ConfigMap` for the CNI Plugin
+#### Create the `ConfigMap` for the CSI Plugin
 
 First, create a `ConfigMap` that contains a YAML manifest with all resources to install the Nutanix CSI driver.
 


### PR DESCRIPTION
CAPX docs across all versions had a typo in a subheading in the addons section conflating CSI with CNI.